### PR TITLE
Add metadata for ansible-galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  author: Jonas Mauer (jam@kabelmail.net)
+  description: "Ansible role for setting up podman."
+  license: MIT
+  min_ansible_version: 2.4
+  platforms:
+    - name: EL
+      versions:
+        - 7
+    - name: Ubuntu
+      versions:
+        - 18.04
+    - name: ArchLinux
+  galaxy_tags:
+    - containers
+    - podman
+dependencies: []


### PR DESCRIPTION
This file is necessary to install this role as dependency of playbook using ansible-galaxy command.

```
$ ansible-galaxy role install https://github.com/jam82/ansible-role-podman.git
```

Signed-off-by: Lukas Bednar <lbednar@redhat.com>