### PR TITLE
Fix an user config permissions and remove trailing spaces

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -32,5 +32,7 @@
   template:
     src: home/libpod.conf.j2
     dest: "{{ getent_passwd[item.key][4] }}/.config/containers/libpod.conf"
+    owner: "{{ getent_passwd[item.key][1] }}"
+    group: "{{ getent_passwd[item.key][2] }}"
   loop: "{{ podman_users|dict2items }}"
   when: getent_passwd[item.key][1]|int >= 1000

--- a/templates/home/libpod.conf.j2
+++ b/templates/home/libpod.conf.j2
@@ -1,25 +1,26 @@
 {{ ansible_managed | comment }}
-volume_path = "{{ getent_passwd[item.key][4] }}/.local/share/containers/storage/volumes"            
-image_default_transport = "docker://"                                             
-runtime = "runc"                                                                  
+volume_path = "{{ getent_passwd[item.key][4] }}/.local/share/containers/storage/volumes"
+image_default_transport = "docker://"
+runtime = "runc"
 conmon_path = ["/usr/libexec/podman/conmon", "/usr/libexec/crio/conmon", "/usr/local/lib/podman/conmon", "/usr/local/libexec/crio/conmon", "/usr/bin/conmon", "/usr/sbin/conmon", "/usr/lib/podman/bin/conmon", "/usr/lib/crio/bin/conmon"]
 conmon_env_vars = ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
-cgroup_manager = "cgroupfs"                                                       
-init_path = "/usr/libexec/podman/catatonit"                                       
-static_dir = "{{ getent_passwd[item.key][4] }}/.local/share/containers/storage/libpod"              
-tmp_dir = "/run/user/{{ getent_passwd[item.key][1] }}/libpod/tmp"                                             
-max_log_size = -1                                                                 
-no_pivot_root = false                                                             
-cni_config_dir = "/etc/cni/net.d/"                                                
+cgroup_manager = "cgroupfs"
+init_path = "/usr/libexec/podman/catatonit"
+static_dir = "{{ getent_passwd[item.key][4] }}/.local/share/containers/storage/libpod"
+tmp_dir = "/run/user/{{ getent_passwd[item.key][1] }}/libpod/tmp"
+max_log_size = -1
+no_pivot_root = false
+cni_config_dir = "/etc/cni/net.d/"
 cni_plugin_dir = ["/usr/libexec/cni", "/usr/lib/cni", "/usr/local/lib/cni", "/opt/cni/bin"]
-infra_image = "k8s.gcr.io/pause:3.1"                                              
-infra_command = "/pause"                                                          
-enable_port_reservation = true                                                    
-label = true                                                                      
-network_cmd_path = ""                                                             
-num_locks = 2048                                                                  
-events_logger = "file"                                                            
-EventsLogFilePath = ""                                                            
-                                                                                  
-[runtimes]                                                                        
-  runc = ["/usr/bin/runc", "/usr/sbin/runc", "/usr/local/bin/runc", "/usr/local/sbin/runc", "/sbin/runc", "/bin/runc", "/usr/lib/cri-o-runc/sbin/runc"]
+infra_image = "k8s.gcr.io/pause:3.1"
+infra_command = "/pause"
+enable_port_reservation = true
+label = true
+network_cmd_path = ""
+num_locks = 2048
+events_logger = "file"
+EventsLogFilePath = ""
+
+[runtimes]
+runc = ["/usr/bin/runc", "/usr/sbin/runc", "/usr/local/bin/runc", "/usr/local/sbin/runc", "/sbin/runc", "/bin/runc", "/usr/lib/cri-o-runc/sbin/runc"]
+


### PR DESCRIPTION
* There was an wrong ownership on libpod.conf file for non-root users.

* It turned out that version of `podman-1.7.0-3.fc30.x86_64` on Fedora 30 has a problem to parse config file with trailing spaces. So removing those from template.